### PR TITLE
Vertical scaling & ID-based population

### DIFF
--- a/assets/javascripts/timeknots.js
+++ b/assets/javascripts/timeknots.js
@@ -1,7 +1,7 @@
 var TimeKnots = {
     draw: function(id, events, options) {
         // remove any exisitng elements
-        d3.select(id).html("");
+        d3.select(id).select("div").html("");
 
         var TODAY = Date.now();
         var cfg = {
@@ -32,7 +32,7 @@ var TimeKnots = {
                 name: cfg.addNowLabel || "Today"
             });
         }
-        var svg = d3.select(id).append('svg').attr("width", cfg.width).attr("height", cfg.height);
+        var svg = d3.select(id).select("div").append('svg').attr("width", cfg.width).attr("height", cfg.height);
         //Calculate times in terms of timestamps
         if (!cfg.dateDimension) {
             var timestamps = events.map(function(d) {

--- a/widgets/timeline/timeline.coffee
+++ b/widgets/timeline/timeline.coffee
@@ -11,4 +11,16 @@ class Dashing.Timeline extends Dashing.Widget
         @renderTimeline(data.events)
 
   renderTimeline: (events) ->
-    TimeKnots.draw(".timeline", events, {horizontalLayout: false, color: "#222222", height: 550, width:340, showLabels: true, labelFormat:"%H:%M"});
+    # Margins: zero if not set or the same as the opposite margin
+    # (you likely want this to keep the chart centered within the widget)
+    left = @get('leftMargin') || 0
+    right = @get('rightMargin') || left
+    top = @get('topMargin') || 0
+    bottom = @get('bottomMargin') || top
+
+    container = $(@node).parent()
+    # Gross hacks. Let's fix this.
+    width = (Dashing.widget_base_dimensions[0] * container.data("sizex")) + Dashing.widget_margins[0] * 2 * (container.data("sizex") - 1) - left - right
+    height = (Dashing.widget_base_dimensions[1] * container.data("sizey")) - ($(@node).find("h1").outerHeight() + 12) - top - bottom
+    id = "." + @get('id')
+    TimeKnots.draw(id, events, {horizontalLayout: false, color: "#222222", height: height, width: width, showLabels: true, labelFormat:"%H:%M"});


### PR DESCRIPTION
Added vertical scaling according to jorgemorgado's (https://github.com/jorgemorgado) widgets, i.e.: https://github.com/jorgemorgado/dashing-linechart/blob/master/line_chart.coffee, this aims to fix issue https://github.com/aysark/dashing-timeline/issues/3.
Also I added rendering based on "data-id" instead of "data-class", 2 timeline widgets on the same page would generate odd results, this is based on my personal convenience.
