### PR TITLE
sort events

### DIFF
--- a/assets/javascripts/timeknots.js
+++ b/assets/javascripts/timeknots.js
@@ -32,6 +32,10 @@ var TimeKnots = {
                 name: cfg.addNowLabel || "Today"
             });
         }
+        //sort events ascending
+        events.sort(function(a,b){
+          return new Date(a.date) - new Date(b.date);
+        });
         var svg = d3.select(id).select("div").append('svg').attr("width", cfg.width).attr("height", cfg.height);
         //Calculate times in terms of timestamps
         if (!cfg.dateDimension) {


### PR DESCRIPTION
seems as if the implementation assumes that the events are ordered.

I ran into the following situation today:
![image](https://user-images.githubusercontent.com/6322123/78507287-868a8b80-777f-11ea-86ff-6ebf7baa40d7.png)
